### PR TITLE
Replace XY position P controller with PID

### DIFF
--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -821,7 +821,7 @@ void ModeGuided::velaccel_control_run()
     bool do_avoid = false;
 #if AP_AVOIDANCE_ENABLED
     // limit the velocity for obstacle/fence avoidance
-    copter.avoid.adjust_velocity(guided_vel_target_cms, pos_control->get_pos_NE_p().kP(), pos_control->get_max_accel_NE_cmss(), pos_control->get_pos_U_p().kP(), pos_control->get_max_accel_U_cmss(), G_Dt);
+    copter.avoid.adjust_velocity(guided_vel_target_cms, pos_control->get_pos_NE_pid().kP(), pos_control->get_max_accel_NE_cmss(), pos_control->get_pos_U_p().kP(), pos_control->get_max_accel_U_cmss(), G_Dt);
     do_avoid = copter.avoid.limits_active();
 #endif
 

--- a/ArduCopter/tuning.cpp
+++ b/ArduCopter/tuning.cpp
@@ -113,7 +113,7 @@ void Copter::tuning(const RC_Channel *tuning_ch, int8_t tuning_param, float tuni
 
     // Loiter and navigation tuning
     case TUNING_LOITER_POSITION_KP:
-        pos_control->get_pos_NE_p().set_kP(tuning_value);
+        pos_control->get_pos_NE_pid().set_kP(tuning_value);
         break;
 
     case TUNING_VEL_XY_KP:

--- a/ArduPlane/tuning.cpp
+++ b/ArduPlane/tuning.cpp
@@ -166,7 +166,7 @@ AP_Float *AP_Tuning_Plane::get_param_pointer(uint8_t parm)
         return &plane.quadplane.attitude_control->get_angle_yaw_p().kP();
 
     case TUNING_PXY_P:
-        return &plane.quadplane.pos_control->get_pos_NE_p().kP();
+        return &plane.quadplane.pos_control->get_pos_NE_pid().kP();
 
     case TUNING_PZ_P:
         return &plane.quadplane.pos_control->get_pos_U_p().kP();

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -6,7 +6,6 @@
 #include <AC_PID/AC_P.h>            // P library
 #include <AC_PID/AC_PID.h>          // PID library
 #include <AC_PID/AC_P_1D.h>         // P library (1-axis)
-#include <AC_PID/AC_P_2D.h>         // P library (2-axis)
 #include <AC_PID/AC_PI_2D.h>        // PI library (2-axis)
 #include <AC_PID/AC_PID_Basic.h>    // PID library (1-axis)
 #include <AC_PID/AC_PID_2D.h>       // PID library (2-axis)
@@ -130,15 +129,15 @@ public:
     void set_pos_error_max_NE_cm(float error_max_cm) { set_pos_error_max_NE_m(error_max_cm * 0.01); }
 
     // Sets maximum allowed horizontal position error in meters.
-    // Used to constrain the output of the horizontal position P controller.
-    void set_pos_error_max_NE_m(float error_max_m) { _p_pos_ne_m.set_error_max(error_max_m); }
+    // Used to constrain the output of the horizontal position PID controller.
+    void set_pos_error_max_NE_m(float error_max_m) { _pos_error_max_ne_m = error_max_m; }
 
     // Returns maximum allowed horizontal position error in cm.
     // See get_pos_error_max_NE_m() for full details.
     float get_pos_error_max_NE_cm() const { return get_pos_error_max_NE_m() * 100.0; }
 
     // Returns maximum allowed horizontal position error in meters.
-    float get_pos_error_max_NE_m() const { return _p_pos_ne_m.get_error_max(); }
+    float get_pos_error_max_NE_m() const { return _pos_error_max_ne_m; }
 
     // Initializes NE controller to a stationary stopping point with zero velocity and acceleration.
     // Use when the expected trajectory begins at rest but the starting position is unspecified.
@@ -689,8 +688,8 @@ public:
 
     /// Other
 
-    // Returns reference to the NE position P controller.
-    AC_P_2D& get_pos_NE_p() { return _p_pos_ne_m; }
+    // Returns reference to the NE position PID controller.
+    AC_PID_2D& get_pos_NE_pid() { return _p_pos_ne_m; }
 
     // Returns reference to the U (vertical) position P controller.
     AC_P_1D& get_pos_U_p() { return _p_pos_u_m; }
@@ -864,7 +863,8 @@ protected:
     AP_Float        _lean_angle_max_deg;    // Maximum autopilot commanded angle (in degrees). Set to zero for Angle Max
     AP_Float        _shaping_jerk_ne_msss;  // Jerk limit of the ne kinematic path generation in m/s³ used to determine how quickly the aircraft varies the acceleration target
     AP_Float        _shaping_jerk_u_msss;   // Jerk limit of the u kinematic path generation in m/s³ used to determine how quickly the aircraft varies the acceleration target
-    AC_P_2D         _p_pos_ne_m;            // XY axis position controller to convert target distance (cm) to target velocity (cm/s)
+    AC_PID_2D       _p_pos_ne_m;            // XY axis position controller to convert target distance (m) to target velocity (m/s)
+    float           _pos_error_max_ne_m;    // maximum allowed horizontal position error in meters
     AC_P_1D         _p_pos_u_m;             // Z axis position controller to convert target altitude (cm) to target climb rate (cm/s)
     AC_PID_2D       _pid_vel_ne_cm;         // XY axis velocity controller to convert target velocity (cm/s) to target acceleration (cm/s²)
     AC_PID_Basic    _pid_vel_u_cm;          // Z axis velocity controller to convert target climb rate (cm/s) to target acceleration (cm/s²)

--- a/libraries/AC_PID/AC_PID_2D.h
+++ b/libraries/AC_PID/AC_PID_2D.h
@@ -47,11 +47,17 @@ public:
     void save_gains();
 
     // get accessors
+    const AP_Float &kP() const { return _kp; }
     AP_Float &kP() { return _kp; }
+    const AP_Float &kI() const { return _ki; }
     AP_Float &kI() { return _ki; }
+    const AP_Float &kD() const { return _kd; }
     AP_Float &kD() { return _kd; }
-    AP_Float &ff() { return _kff;}
+    const AP_Float &ff() const { return _kff; }
+    AP_Float &ff() { return _kff; }
+    const AP_Float &filt_E_hz() const { return _filt_E_hz; }
     AP_Float &filt_E_hz() { return _filt_E_hz; }
+    const AP_Float &filt_D_hz() const { return _filt_D_hz; }
     AP_Float &filt_D_hz() { return _filt_D_hz; }
     float imax() const { return _kimax.get(); }
     float get_filt_E_alpha(float dt) const;

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -341,7 +341,7 @@ void AC_Loiter::calc_desired_velocity(bool avoidance_on)
         AC_Avoid *_avoid = AP::ac_avoid();
         if (_avoid != nullptr) {
             Vector3f avoidance_vel_neu_cms{desired_vel_ne_ms.x * 100.0, desired_vel_ne_ms.y * 100.0, 0.0f};
-            _avoid->adjust_velocity(avoidance_vel_neu_cms, _pos_control.get_pos_NE_p().kP(), _accel_max_ne_cmss, _pos_control.get_pos_U_p().kP(), _pos_control.get_max_accel_U_cmss(), dt_s);
+            _avoid->adjust_velocity(avoidance_vel_neu_cms, _pos_control.get_pos_NE_pid().kP(), _accel_max_ne_cmss, _pos_control.get_pos_U_p().kP(), _pos_control.get_max_accel_U_cmss(), dt_s);
             desired_vel_ne_ms = avoidance_vel_neu_cms.xy() * 0.01;
         }
     }

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -548,7 +548,7 @@ bool AC_WPNav::advance_wp_target_along_track(float dt)
         const float track_error_neu_m = _pos_control.get_pos_error_NEU_m().dot(track_direction_neu);
         const float track_velocity_neu_ms = _pos_control.get_vel_estimate_NEU_ms().dot(track_direction_neu);
         // limit time step scalar to [0,1], with 5% buffer
-        track_dt_scalar = constrain_float(0.05f + (track_velocity_neu_ms - _pos_control.get_pos_NE_p().kP() * track_error_neu_m) / curr_target_vel_neu_ms.length(), 0.0f, 1.0f);
+        track_dt_scalar = constrain_float(0.05f + (track_velocity_neu_ms - _pos_control.get_pos_NE_pid().kP() * track_error_neu_m) / curr_target_vel_neu_ms.length(), 0.0f, 1.0f);
     }
 
     // compute velocity scaling (vel_dt_scalar) and apply jerk-limited velocity shaping


### PR DESCRIPTION
## Summary
- switch horizontal position control from P-only to full AC_PID_2D controller
- add PID defaults and clamp position error before computing velocity targets
- update call sites to use new `get_pos_NE_pid` accessor
- cast NE position target and measurements to floats before invoking the PID to avoid type mismatches
- provide const accessors for AC_PID_2D gains to fix const-correctness in helper routines